### PR TITLE
[fix]검색어가 존재하지않으면 값을 에러발생 #120

### DIFF
--- a/services/search.sevice.js
+++ b/services/search.sevice.js
@@ -15,6 +15,10 @@ class SearchService {
    */
   search = async (result, userEmail) => {
     const searchText = result.value;
+    console.log("=========", searchText);
+    if (!searchText) {
+      return Boom.notFound("검색어가 존재하지 않습니다.");
+    }
     const artgramTitles = await this.searchRepositroy.autocompleteArtgrams(
       searchText,
       userEmail


### PR DESCRIPTION
검색어값이 들어오지않을때 
빈값인 상황이면 아트그램의 글이 
디폴트값으로 들어오는 오류가 있어서 해결함검색어값이 들어오지않을때 
빈값인 상황이면 아트그램의 글이 
디폴트값으로 들어오는 오류가 있어서 해결함