### PR TITLE
[fix]전시회검색시 바로 상세조회로 들어갈수잇는 url추가#120

### DIFF
--- a/repositories/search.repository.js
+++ b/repositories/search.repository.js
@@ -309,6 +309,7 @@ class SearchRepositroy extends SearchHistory {
 
         const exhibitionObject = {
           ...rest,
+          detailRouter: `/exhibition/detail/${exhibitionId}`,
           type: "exhibition",
           liked: !!likedByCurrentUser,
           scrap: !!scrapByCurrentUser,


### PR DESCRIPTION
전시회에서 검색시 받아오는 id값을
바로 url로 보내줄수있는 detailRouter추가