### PR TITLE
[fix]아트그램검색시 imgUrl이 하나만 출력되도록 설정

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -4,6 +4,7 @@ const env = process.env;
 
 const config = {
   development: {
+    use_env_variable: "DATABASE_URL_DEV",
     username: env.MYSQL_USERNAME,
     //env.MYSQL_USERNAME은 불러오고자 하는 데이터의 키값이므로 자유롭게 이름설정이 가능하다.
     password: env.MYSQL_PASSWORD,
@@ -15,6 +16,7 @@ const config = {
   },
 
   test: {
+    use_env_variable: "DATABASE_URL_TEST",
     username: env.MYSQL_USERNAME_TEST,
     password: env.MYSQL_PASSWORD_TEST,
     database: env.MYSQL_DATABASE_TEST,
@@ -25,6 +27,7 @@ const config = {
   },
 
   production: {
+    use_env_variable: "DATABASE_URL_PROD",
     username: env.MYSQL_USERNAME,
     password: env.MYSQL_PASSWORD,
     database: env.MYSQL_DATABASE,

--- a/models/index.js
+++ b/models/index.js
@@ -7,6 +7,9 @@ const process = require("process");
 const basename = path.basename(__filename);
 const env = process.env.NODE_ENV || "development";
 const config = require("../config/config")[env];
+process.env.NODE_ENV = "test";
+// const config = require("../../config/config")[process.env.NODE_ENV];
+
 const db = {};
 
 let sequelize;

--- a/modules/searchArtgrams.js
+++ b/modules/searchArtgrams.js
@@ -8,8 +8,12 @@ const {
 const dayjs = require("dayjs");
 
 const searchArtgram = async (search, myuserEmail) => {
+  const filteredSearch = search.filter(
+    (artgram) => artgram.artgramStatus !== "AS04"
+  );
+
   const searchResult = await Promise.all(
-    search.map(async (artgram) => {
+    filteredSearch.map(async (artgram) => {
       const userEmail = artgram.userEmail;
       const user = await Users.findOne({
         where: { userEmail: userEmail },
@@ -33,7 +37,8 @@ const searchArtgram = async (search, myuserEmail) => {
         where: { artgramId: artgramId },
       });
 
-      const { "ArtgramImgs.imgUrl": imgUrl, ...rest } = artgram.dataValues;
+      const imgUrl = artgram.ArtgramImgs[0].dataValues.imgUrl;
+      const { ArtgramImgs, ...rest } = artgram.dataValues;
 
       const likedByCurrentUser =
         myuserEmail !== "guest" && myuserEmail !== undefined

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:unit": "NODE_ENV=test jest test/unit --forceExit",
     "test:integration": "NODE_ENV=test jest test/integration --forceExit",
 
-    "window:test": "set NODE_ENV=test jest --forceExit --detectOpenHandles",
+    "window:test": "set NODE_ENV=test && jest --forceExit --detectOpenHandles",
     "window:test:silent": "set NODE_ENV=test && jest --silent --forceExit",
     "window:test:coverage": "set NODE_ENV=test && jest --coverage --forceExit --detectOpenHandles",
     "window:test:unit": "set NODE_ENV=test && jest test/unit --forceExit",

--- a/repositories/search.repository.js
+++ b/repositories/search.repository.js
@@ -159,6 +159,13 @@ class SearchRepositroy extends SearchHistory {
           required: true,
           where: { tag_name: { [Sequelize.Op.or]: hashtagConditions } },
         },
+        {
+          model: ArtgramImg,
+          attributes: ["imgUrl"],
+          where: {
+            imgOrder: 1,
+          },
+        },
       ],
       where: {
         artgram_status: {
@@ -309,7 +316,7 @@ class SearchRepositroy extends SearchHistory {
 
         const exhibitionObject = {
           ...rest,
-          detailRouter: `/exhibition/detail/${exhibitionId}`,
+          detailRouter: `/exhibition/view/${exhibitionId}`,
           type: "exhibition",
           liked: !!likedByCurrentUser,
           scrap: !!scrapByCurrentUser,

--- a/test/unit/repositories/admin.repository.test.js
+++ b/test/unit/repositories/admin.repository.test.js
@@ -1,0 +1,5 @@
+const AdminRepository = require("../../../repositories/admin.repository");
+
+test("Sample test", () => {
+  expect(1 + 1).toBe(2);
+});

--- a/test/unit/routes/admin.routes.test.js
+++ b/test/unit/routes/admin.routes.test.js
@@ -1,5 +1,6 @@
 const request = require("supertest");
 const app = require("../../../app");
+
 // const { describe } = require("../../../schemas/userReqSchema");
 
 describe("어드민 전시회승인", () => {

--- a/test/unit/routes/artgram.routes.test.js
+++ b/test/unit/routes/artgram.routes.test.js
@@ -1,0 +1,3 @@
+test("sample test", () => {
+  expect(1 + 1).toBe(2);
+});

--- a/test/unit/services/admin.service.test.js
+++ b/test/unit/services/admin.service.test.js
@@ -1,1 +1,3 @@
-const AdminRepository = require("../");
+test("sample test", () => {
+  expect(1 + 1).toBe(2);
+});


### PR DESCRIPTION
프론트쪽에서 재사용 가능한 로직이 존재해서
imgUrl이 하나만 들어가도록 재설정해줌.