### PR TITLE
[fix]검색저장부분 테이블이름변경으로 인한 오류#122

### DIFF
--- a/repositories/search.repository.js
+++ b/repositories/search.repository.js
@@ -36,7 +36,7 @@ class SearchRepositroy extends SearchHistory {
    * @returns
    */
   selectResult = async (title, type, userEmail) => {
-    const savedResult = await searchHistory.create({
+    const savedResult = await SearchHistory.create({
       keyWord: title,
       type: type,
       userEmail: userEmail,
@@ -334,7 +334,7 @@ class SearchRepositroy extends SearchHistory {
 
         const exhibitionObject = {
           ...rest,
-          detailRouter: `/exhibition/view/${exhibitionId}`,
+          detailRouter: `/exhibition/detail/${exhibitionId}`,
           address,
           type: "exhibition",
           liked: !!likedByCurrentUser,


### PR DESCRIPTION
전에 모델명이 
searchHistory로 설정되있던 부분이
다른 모델들과 다른 방식으로 설정되어있어서

SearchHistory로 변경하면서
변경되지않은 부분들이 있어서 그부분에서 에러가 발생함