### PR TITLE
[feat]ColudFlare Images 업로드 허용 제공URL API추가

### DIFF
--- a/controllers/upload.controller.js
+++ b/controllers/upload.controller.js
@@ -1,0 +1,51 @@
+
+// router.get("/exhibition/postimage", authMiddleware, uploadController.getExhibitionPostImageUploadUrl);
+// // 전시회 상세 사진
+// router.get("/exhibition/artimage", authMiddleware, uploadController.getExhibitionArtImageUploadUrl);
+// // 프로필 사진
+// router.get("/profile/userimage", authMiddleware, uploadController.getProfileUserImageUploadUrl);
+// // 아트그램 사진
+// router.post("/artgram/image", authMiddleware, uploadController.getArtgramImageUploadUrl);
+// // 채팅 업로드 URL
+// router.get("/chat/image", authMiddleware, uploadController.getChatImageUploadUrl);
+const axios = require("axios");
+require("dotenv").config();
+
+const url = `https://api.cloudflare.com/client/v4/accounts/${process.env.CLOUDFLARE_ACCOUNT_ID}/images/v2/direct_upload`;
+const token = `${process.env.CLOUDFLARE_API_KEY}`;
+
+// CLOUDFLARE_ACCOUNT_ID=b145a7d17d0cca83dce09f90b0265908
+// CLOUDFLARE_API_KEY=7DM6tVajxmN4HrmbQjG7UqdFghmSvqXg
+
+class UploadController {
+  /**
+   * 전시회 포스트 이미지
+   */
+  getImageUploadUrl = async (req, res, next) => {
+
+    const { reqCnt = 1 } = req.query;
+
+    try {
+      const requests = Array.from({ length: reqCnt }, () =>
+        axios(url, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        })
+      );
+  
+      const responses = await Promise.all(requests);
+      const data = responses.map((response) => response.data);
+  
+      res.json({
+        urlData: data,
+        message: "정상적으로 이미지 업로드 URL을 조회했습니다.",
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+}
+
+module.exports = UploadController;

--- a/routes/index.js
+++ b/routes/index.js
@@ -13,6 +13,7 @@ const notiRouter = require("./notification.routes");
 const reportRouter = require("./report.routes");
 const adminRouter = require("./admin.routes");
 const chatRouter = require("./chat.routes");
+const uploadRouter = require("./upload.routes");
 
 router.use("/auth", userRouter);
 router.use("/artgram", [artgramRouter, artgramCommentRouter]);
@@ -24,5 +25,6 @@ router.use("/notification", notiRouter);
 router.use("/report", reportRouter);
 router.use("/admin", adminRouter);
 router.use("/chat", chatRouter);
+router.use("/upload", uploadRouter);
 
 module.exports = router;

--- a/routes/upload.routes.js
+++ b/routes/upload.routes.js
@@ -1,0 +1,12 @@
+const express = require("express");
+const router = express.Router();
+
+const authMiddleware = require('../middlewares/authMiddleware');
+
+const UploadController = require("../controllers/upload.controller")
+const uploadController = new UploadController();
+
+// CLOUDFLARE IMAGES URL 요청
+router.get("/", authMiddleware, uploadController.getImageUploadUrl);
+
+module.exports = router;


### PR DESCRIPTION
### CloudFlare Images 크리에이터 직접 업로드 방식을 위한 엑세스 URL 제공 API 추가.
- GET /upload?reqcnt=5 와 같은 방식으로 호출 가능. 