### PR TITLE
[fix]api호출횟수 조회 예외처리 #384

### DIFF
--- a/app.js
+++ b/app.js
@@ -119,6 +119,9 @@ app.use(
           .filter((segment) => segment && segment !== "api");
 
         const apiName = getApiName(apiSegments);
+        if (apiName === "exclude") {
+          return;
+        }
         const isDetail = shouldAddDetail(apiName, apiSegments);
 
         incrementCounter(apiName, method);

--- a/modules/counter.js
+++ b/modules/counter.js
@@ -1,4 +1,12 @@
 function getApiName(apiSegments) {
+  if (
+    apiSegments[0] === "banner" ||
+    apiSegments[0] === "admin" ||
+    apiSegments[0] === "notification" ||
+    apiSegments[0] === "search"
+  ) {
+    return "exclude";
+  }
   if (apiSegments[0] === "auth") {
     return apiSegments[1];
   } else if (apiSegments[0] === "artgram") {
@@ -54,7 +62,7 @@ function getApiName(apiSegments) {
       return "banner";
     }
   } else {
-    return `${apiSegments[0]}-${apiSegments[1] || "undefinedAPI"}`;
+    return "exclude";
   }
 }
 


### PR DESCRIPTION
api호출횟수 조회하는 로직에서
설정하지않은 값들이 들어오면 에러가 발생해서
예외처리를 해줌

//api별로 조회하는 부분
//modules/counter.js
//function getApiName
if (
    apiSegments[0] === "banner" ||
    apiSegments[0] === "admin" ||
    apiSegments[0] === "notification" ||
    apiSegments[0] === "search"
  ) {
    return "exclude";
  }else {
    return "exclude";
  }
  
//app.js에서 winston연결하는부분
  const apiName = getApiName(apiSegments);
        if (apiName === "exclude") {
          return;
        }