### PR TITLE
[fix]전시 조회 시 리뷰 평점 삭제된 리뷰도 반영된 것 변경 #162

### DIFF
--- a/repositories/exhibition.repository.js
+++ b/repositories/exhibition.repository.js
@@ -357,7 +357,12 @@ class ExhibitionRepository {
           "ratingFiveCnt",
         ],
       ],
-      where: { exhibitionId },
+      where: {
+        [Op.and]: [
+          { exhibitionId },
+          { exhibition_status: { [Op.ne]: ["ES04"] } },
+        ],
+      },
     });
 
     const liked = await ExhibitionLike.findOne({


### PR DESCRIPTION
평점 조회 시 삭제된 리뷰는 반영해선 안되지만 이 부분이 누락되어 수정함.