### PR TITLE
[fix]프록시서버 환경변수로설정

### DIFF
--- a/app.js
+++ b/app.js
@@ -167,14 +167,19 @@ app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 passportConfig(); // 패스포트 설정
 
 // frontend proxy
-app.use(
-  "/",
-  createProxyMiddleware({
-    target: "https://museoh.art",
+//프록시 환경변수 등록해서 테스트서버에서는 실행되지않도록 설정
+const proxyTarget = process.env.REACT_APP_PROXY_TARGET;
+const enableProxy = process.env.REACT_APP_ENABLE_PROXY === "true";
 
-    changeOrigin: true,
-  })
-);
+if (enableProxy) {
+  app.use(
+    "/",
+    createProxyMiddleware({
+      target: proxyTarget,
+      changeOrigin: true,
+    })
+  );
+}
 
 // errorHandler
 app.use((err, req, res, next) => {

--- a/test/scenarios.yaml
+++ b/test/scenarios.yaml
@@ -1,19 +1,19 @@
 config:
-  target: "https://localhost:3000/api"
+  target: "http://3.87.217.12/api"
   variables:
     MYSQL_USERNAME_TEST: "{$.env.MYSQL_USERNAME_TEST}"
     MYSQL_HOST_TEST: "{$.env.MYSQL_HOST_TEST}"
     MYSQL_PASSWORD_TEST: "{$.env.MYSQL_PASSWORD_TEST}"
   phases:
-    - duration: 60
+    - duration: 10
       arrivalRate: 5
       name: Warm up
-    - duration: 120
-      arrivalRate: 5
-      rampTo: 50
+    - duration: 60
+      arrivalRate: 10
+      rampTo: 20
       name: Ramp up load
 scenarios:
-  - name: "전시회조회"
+  - name: "아트그램조회"
     flow:
       - { "get": { "url": "/" } }
       - post:
@@ -21,4 +21,10 @@ scenarios:
           json:
             email: "ekqls6812@dd.com"
             password: "a!111222"
-      - { "get": { "url": "/exhibition" } }
+          capture:
+            - json: "$.token"
+              as: "auth_token"
+      - get:
+          url: "/artgram?limit=10&offset=0"
+          headers:
+            Authorization: "Bearer {{ auth_token }}"


### PR DESCRIPTION
테스트서버에서 스트레스테스트 진행시
서버에 무리가지않도록 

테스트용 데이터베이스에서 실행가능하도록
프록시서버를 환경변수로 실행해줌.

REACT_APP_ENABLE_PROXY=false
면 프록시서버가 실행되지않음


const proxyTarget = process.env.REACT_APP_PROXY_TARGET;
const enableProxy = process.env.REACT_APP_ENABLE_PROXY === "true";

if (enableProxy) {
  app.use(
    "/",
    createProxyMiddleware({
      target: proxyTarget,
      changeOrigin: true,
    })
  );
}